### PR TITLE
Improve props display

### DIFF
--- a/example/src/Box/Box.stories.tsx
+++ b/example/src/Box/Box.stories.tsx
@@ -7,9 +7,9 @@ export default {
   parameters: {
     matrix: {
       pattern: {
-        bg: ['white', 'blue', 'red', 'yellow'],
+        bg: [undefined, 'red', 'yellow'],
         bool: [true, false],
-        width: [1, '50%', 256],
+        width: [undefined, '50%', 256],
         p: [undefined, 2, 3],
       },
     },

--- a/example/src/Box/Box.stories.tsx
+++ b/example/src/Box/Box.stories.tsx
@@ -8,6 +8,7 @@ export default {
     matrix: {
       pattern: {
         bg: ['white', 'blue', 'red', 'yellow'],
+        bool: [true, false],
         width: [1, '50%', 256],
         p: [undefined, 2, 3],
       },

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -285,7 +285,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-ahhrdi"
+                            className="css-12p2gsl"
                             color="rgba(51, 51, 51, 0.25)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
@@ -329,7 +329,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
+                            className="css-8v37fk"
                             color="rgba(51, 51, 51, 0.75)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
@@ -448,7 +448,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
+                            className="css-8v37fk"
                             color="rgba(51, 51, 51, 0.75)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
@@ -492,7 +492,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
+                            className="css-8v37fk"
                             color="rgba(51, 51, 51, 0.75)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
@@ -615,7 +615,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-ahhrdi"
+                            className="css-12p2gsl"
                             color="rgba(51, 51, 51, 0.25)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
@@ -659,7 +659,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
+                            className="css-8v37fk"
                             color="rgba(51, 51, 51, 0.75)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
@@ -778,7 +778,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
+                            className="css-8v37fk"
                             color="rgba(51, 51, 51, 0.75)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
@@ -822,7 +822,7 @@ Array [
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
+                            className="css-8v37fk"
                             color="rgba(51, 51, 51, 0.75)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -278,14 +278,15 @@ Array [
                             title
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
-                          color="rgba(51, 51, 51, 0.75)"
+                          color="rgba(51, 51, 51, 0.25)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
-                            color="rgba(51, 51, 51, 0.75)"
+                            className="css-ahhrdi"
+                            color="rgba(51, 51, 51, 0.25)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
                             undefined
@@ -321,7 +322,8 @@ Array [
                             text
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
                           color="rgba(51, 51, 51, 0.75)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
@@ -439,7 +441,8 @@ Array [
                             title
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
                           color="rgba(51, 51, 51, 0.75)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
@@ -482,7 +485,8 @@ Array [
                             text
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
                           color="rgba(51, 51, 51, 0.75)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
@@ -604,14 +608,15 @@ Array [
                             title
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
-                          color="rgba(51, 51, 51, 0.75)"
+                          color="rgba(51, 51, 51, 0.25)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                         >
                           <span
-                            className="css-mtjg0i"
-                            color="rgba(51, 51, 51, 0.75)"
+                            className="css-ahhrdi"
+                            color="rgba(51, 51, 51, 0.25)"
                             fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
                           >
                             undefined
@@ -647,7 +652,8 @@ Array [
                             text
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
                           color="rgba(51, 51, 51, 0.75)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
@@ -765,7 +771,8 @@ Array [
                             title
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
                           color="rgba(51, 51, 51, 0.75)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"
@@ -808,7 +815,8 @@ Array [
                             text
                           </span>
                         </Styled(span)>
-                        : 
+                        :
+                         
                         <Styled(span)
                           color="rgba(51, 51, 51, 0.75)"
                           fontFamily="\\"Nunito Sans\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif"

--- a/src/components/Matrix/Matrix.tsx
+++ b/src/components/Matrix/Matrix.tsx
@@ -33,7 +33,12 @@ export const Matrix: React.FC<MatrixProps> = ({ component, propsPattern, origina
                   <Text fontWeight="bold" color="rgba(51, 51, 51, 0.75)">
                     {key}
                   </Text>
-                  : <Text color="rgba(51, 51, 51, 0.75)">{`${value}`}</Text>
+                  :{' '}
+                  <Text
+                    color={
+                      value === undefined ? 'rgba(51, 51, 51, 0.25)' : 'rgba(51, 51, 51, 0.75)'
+                    }
+                  >{`${value}`}</Text>
                 </Box>
               </Box>
             ))}

--- a/src/components/Matrix/Matrix.tsx
+++ b/src/components/Matrix/Matrix.tsx
@@ -33,7 +33,7 @@ export const Matrix: React.FC<MatrixProps> = ({ component, propsPattern, origina
                   <Text fontWeight="bold" color="rgba(51, 51, 51, 0.75)">
                     {key}
                   </Text>
-                  : <Text color="rgba(51, 51, 51, 0.75)">{value ?? 'undefined'}</Text>
+                  : <Text color="rgba(51, 51, 51, 0.75)">{`${value}`}</Text>
                 </Box>
               </Box>
             ))}

--- a/src/components/Matrix/Matrix.tsx
+++ b/src/components/Matrix/Matrix.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import * as React from 'react';
 import { Box } from '../Box';
-import { Text } from '../Text';
+import { Text, OverflowWrapText } from '../Text';
 import { Flex } from '../Flex';
 import { createPropsCombinations } from '../../createPropsCombinations';
 
@@ -34,11 +34,11 @@ export const Matrix: React.FC<MatrixProps> = ({ component, propsPattern, origina
                     {key}
                   </Text>
                   :{' '}
-                  <Text
+                  <OverflowWrapText
                     color={
                       value === undefined ? 'rgba(51, 51, 51, 0.25)' : 'rgba(51, 51, 51, 0.75)'
                     }
-                  >{`${value}`}</Text>
+                  >{`${value}`}</OverflowWrapText>
                 </Box>
               </Box>
             ))}

--- a/src/components/Text/OverflowWrapText.tsx
+++ b/src/components/Text/OverflowWrapText.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import { Text } from './Text';
+import { TextProps } from './types';
+
+export const OverflowWrapText: React.FC<TextProps> = styled(Text)`
+  overflow-wrap: anywhere;
+`;

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,2 +1,3 @@
 export { Text } from './Text';
+export { OverflowWrapText } from './OverflowWrapText';
 export { TextProps } from './types';


### PR DESCRIPTION
- Show all literal value as string
- Display undefined in light gray
- props value wrap anywhere

![image](https://user-images.githubusercontent.com/18009/81147191-c29a5180-8fb4-11ea-8c0f-015f2d8a02e6.png)
