### PR TITLE
Update getParameters destructuring

### DIFF
--- a/src/services/getParameters.ts
+++ b/src/services/getParameters.ts
@@ -11,8 +11,8 @@ export type Parameters = {
   showOriginal: Boolean;
 };
 
-export function getParameters({ parameters }: StoryContext): Parameters {
-  const { component, matrix } = parameters;
+export function getParameters({ component, parameters }: StoryContext): Parameters {
+  const { matrix } = parameters;
   const { errors } = validateParameters({ component, matrix });
   if (!matrix) {
     return {


### PR DESCRIPTION
Addresses the issue in #42, where a `Default export component must be present` error would appear after updating from Storybook 6.3.x to 6.4.x. This was due to a change in the `StoryContext` structure, where `component` is now a sibling of `parameters` rather than a child.